### PR TITLE
Drop .NET 8 support from main

### DIFF
--- a/src/Ametrin.Optional.csproj
+++ b/src/Ametrin.Optional.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Extensions/DictionaryExtensions.cs
+++ b/src/Extensions/DictionaryExtensions.cs
@@ -7,7 +7,6 @@ public static class DictionaryExtensions
     public static Option<TValue> TryGetValue<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key) where TKey : notnull
         => dictionary.TryGetValue(key, out var result) ? result : default(Option<TValue>);
 
-#if NET9_0_OR_GREATER
     public static Option<TValue> TryGetValue<TKey, TValue, TAlternate>(this Dictionary<TKey, TValue>.AlternateLookup<TAlternate> lookup, TAlternate key) 
     where TKey : notnull 
     where TAlternate : notnull, allows ref struct
@@ -17,5 +16,4 @@ public static class DictionaryExtensions
     where TKey : notnull 
     where TAlternate : notnull, allows ref struct
         => lookup.TryGetValue(key, out var result) ? result : default(Option<TValue>);
-#endif
 }

--- a/src/Operations/Or.cs
+++ b/src/Operations/Or.cs
@@ -2,9 +2,7 @@ namespace Ametrin.Optional;
 
 partial struct Option<TValue>
 {
-#if NET9_0_OR_GREATER
     [OverloadResolutionPriority(1)] // to allow 'Or(default)' which would normally be ambigious
-#endif
     public TValue Or(TValue other) => _hasValue ? _value : other;
     public TValue Or(Func<TValue> factory) => _hasValue ? _value! : factory();
     public TValue OrThrow() => _hasValue ? _value : throw new NullReferenceException("Option is Error state");
@@ -12,9 +10,7 @@ partial struct Option<TValue>
 
 partial struct Result<TValue>
 {
-#if NET9_0_OR_GREATER
     [OverloadResolutionPriority(1)]
-#endif
     public TValue Or(TValue other) => _hasValue ? _value : other;
     public TValue Or(Func<Exception, TValue> factory) => _hasValue ? _value : factory(_error);
     public TValue OrThrow() => _hasValue ? _value : throw new NullReferenceException("Result is Error state", _error);
@@ -22,9 +18,7 @@ partial struct Result<TValue>
 
 partial struct Result<TValue, TError>
 {
-#if NET9_0_OR_GREATER
     [OverloadResolutionPriority(1)]
-#endif
     public TValue Or(TValue other) => _hasValue ? _value! : other;
     public TValue Or(Func<TError, TValue> factory) => _hasValue ? _value! : factory(_error);
     public TValue OrThrow() => _hasValue ? _value! : throw new NullReferenceException($"Result is Error state: {_error}");


### PR DESCRIPTION
- [x] remove .NET 8 target
- [x] remove NET_9+ preprocessors
- [x] create .net 8 branch before merging ([net-8](https://github.com/BarionLP/Ametrin.Optional/tree/net-8))

The reason why we are dropping .net 8 from the main branch is to allow the easier use of .NET 9 features. Especially the `allows ref struct` constrain and the planned #3

Backport PRs are always welcome