### PR TITLE
`MapError` API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## 0.2.3 (unreleased)
+- added `.MapError()` (replaces `.Map(map, errorMap)` overloads)
 - added custom exceptions for `.OrThrow()`
-- removed obsolete `Where(Not)`. Use `Require`/`Reject` instead
+- removed obsolete `Where(Not)`. Use `Require`/`Reject` instead.
 - updated TUnit to 0.19.148
 
 ## 0.2.2

--- a/src/Operations/Map.cs
+++ b/src/Operations/Map.cs
@@ -18,6 +18,8 @@ partial struct Result<TValue>
 {
     public Result<TResult> Map<TResult>(Func<TValue, TResult> map)
         => _hasValue ? map(_value) : _error;
+    
+    [Obsolete("use Map and MapError")]
     public Result<TResult, TNewError> Map<TResult, TNewError>(Func<TValue, TResult> map, Func<Exception, TNewError> errorMap)
         => _hasValue ? map(_value) : errorMap(_error);
     public Result<TResult> Map<TResult>(Func<TValue, Result<TResult>> map)
@@ -30,6 +32,8 @@ partial struct Result<TValue, TError>
         => _hasValue ? map(_value) : _error;
     public Result<TResult> Map<TResult>(Func<TValue, TResult> map, Func<TError, Exception> errorMap)
         => _hasValue ? map(_value) : errorMap(_error);
+
+    [Obsolete("use Map and MapError")]
     public Result<TResult, TNewError> Map<TResult, TNewError>(Func<TValue, TResult> map, Func<TError, TNewError> errorMap)
         => _hasValue ? map(_value) : errorMap(_error);
     public Result<TResult, TError> Map<TResult>(Func<TValue, Result<TResult, TError>> map)

--- a/src/Operations/MapAsync.cs
+++ b/src/Operations/MapAsync.cs
@@ -50,6 +50,8 @@ public static class OptionMapAsyncExtensions
         => (await optionTask).Map(map);
     public static async Task<Result<TResult>> MapAsync<TValue, TResult>(this Task<Result<TValue>> optionTask, Func<TValue, Result<TResult>> map)
         => (await optionTask).Map(map);
+
+    [Obsolete("use MapAsync and MapError")]
     public static async Task<Result<TResult, TNewError>> MapAsync<TValue, TResult, TNewError>(this Task<Result<TValue>> optionTask, Func<TValue, TResult> map, Func<Exception, TNewError> errorMap)
         => (await optionTask).Map(map, errorMap);
     public static async Task<Result<TResult>> MapAsync<TValue, TResult>(this Task<Result<TValue>> resultTask, Func<TValue, Task<TResult>> map)
@@ -65,6 +67,8 @@ public static class OptionMapAsyncExtensions
     [OverloadResolutionPriority(1)]
     public static async Task<Result<TResult, Exception>> MapAsync<TValue, TError, TResult>(this Task<Result<TValue, TError>> optionTask, Func<TValue, TResult> map, Func<TError, Exception> errorMap)
         => (await optionTask).Map(map, errorMap);
+
+    [Obsolete("use MapAsync and MapError")]
     public static async Task<Result<TResult, TNewError>> MapAsync<TValue, TError, TResult, TNewError>(this Task<Result<TValue, TError>> optionTask, Func<TValue, TResult> map, Func<TError, TNewError> errorMap)
         => (await optionTask).Map(map, errorMap);
     public static async Task<Result<TResult, TError>> MapAsync<TValue, TError, TResult>(this Task<Result<TValue, TError>> resultTask, Func<TValue, Task<TResult>> map)

--- a/src/Operations/MapError.cs
+++ b/src/Operations/MapError.cs
@@ -1,0 +1,54 @@
+using System.Threading.Tasks;
+
+namespace Ametrin.Optional;
+
+partial struct Result<TValue>
+{
+    public Result<TValue, TNewError> MapError<TNewError>(Func<Exception, TNewError> errorMap)
+        => _hasValue ? _value : errorMap(_error);
+    public Result<TValue> MapError(Func<Exception, Exception> errorMap)
+        => _hasValue ? _value : errorMap(_error);
+}
+
+partial struct Result<TValue, TError>
+{
+    public Result<TValue> MapError(Func<TError, Exception> errorMap)
+        => _hasValue ? _value : errorMap(_error);
+    public Result<TValue, TNewError> MapError<TNewError>(Func<TError, TNewError> errorMap)
+        => _hasValue ? _value : errorMap(_error);
+}
+
+partial struct ErrorState
+{
+    public ErrorState<TNewError> MapError<TNewError>(Func<Exception, TNewError> errorMap)
+        => _isError ? errorMap(_error) : default(ErrorState<TNewError>);
+    public ErrorState MapError(Func<Exception, Exception> errorMap)
+        => _isError ? errorMap(_error) : default(ErrorState);
+}
+
+partial struct ErrorState<TError>
+{
+    public ErrorState MapError(Func<TError, Exception> errorMap)
+        => _isError ? errorMap(_error) : default(ErrorState);
+    public ErrorState<TNewError> MapError<TNewError>(Func<TError, TNewError> errorMap)
+        => _isError ? errorMap(_error) : default(ErrorState<TNewError>);
+}
+
+public static class OptionMapErrorAsyncExtensions
+{
+    public static async Task<Result<TValue, TNewError>> MapError<TValue, TNewError>(this Task<Result<TValue>> optionalTask, Func<Exception, TNewError> errorMap)
+        => (await optionalTask).MapError(errorMap);
+
+    public static async Task<Result<TValue>> MapError<TValue, TError, TNewError>(this Task<Result<TValue, TError>> optionalTask, Func<TError, Exception> errorMap)
+        => (await optionalTask).MapError(errorMap);
+    public static async Task<Result<TValue, TNewError>> MapError<TValue, TError, TNewError>(this Task<Result<TValue, TError>> optionalTask, Func<TError, TNewError> errorMap)
+        => (await optionalTask).MapError(errorMap);
+
+    public static async Task<ErrorState<TNewError>> MapError<TNewError>(this Task<ErrorState> optionalTask, Func<Exception, TNewError> errorMap)
+        => (await optionalTask).MapError(errorMap);
+
+    public static async Task<ErrorState> MapError<TError>(this Task<ErrorState<TError>> optionalTask, Func<TError, Exception> errorMap)
+        => (await optionalTask).MapError(errorMap);
+    public static async Task<ErrorState<TNewError>> MapError<TError, TNewError>(this Task<ErrorState<TError>> optionalTask, Func<TError, TNewError> errorMap)
+        => (await optionalTask).MapError(errorMap);
+}

--- a/test/MapErrorTests.cs
+++ b/test/MapErrorTests.cs
@@ -1,0 +1,32 @@
+namespace Ametrin.Optional.Test;
+
+public sealed class MapErrorTests
+{
+    [Test]
+    public async Task MapError_Success_Test()
+    {
+        await Assert.That(Result.Success(1).MapError(e => e.Message)).IsSuccess(1);
+        await Assert.That(Result.Success(1).MapError(e => e.InnerException!)).IsSuccess(1);
+        await Assert.That(Result.Success<int, string>(1).MapError(e => new Exception(e))).IsSuccess(1);
+        await Assert.That(Result.Success<int, string>(1).MapError(e => e.GetHashCode())).IsSuccess(1);
+
+        await Assert.That(ErrorState.Success().MapError(e => e.Message)).IsSuccess();
+        await Assert.That(ErrorState.Success().MapError(e => e.InnerException!)).IsSuccess();
+        await Assert.That(ErrorState.Success<string>().MapError(e => new Exception(e))).IsSuccess();
+        await Assert.That(ErrorState.Success<string>().MapError(e => e.GetHashCode())).IsSuccess();
+    }
+
+    [Test]
+    public async Task MapError_Error_Test()
+    {
+        await Assert.That(Result.Error<int>(new Exception("hello")).MapError(e => e.Message)).IsError("hello");
+        await Assert.That(Result.Error<int>(new Exception(null, new NotImplementedException())).MapError(e => e.InnerException!)).IsErrorOfType<int, NotImplementedException>();
+        await Assert.That(Result.Error<int, string>("nay").MapError(e => new Exception(e))).IsError();
+        await Assert.That(Result.Error<int, string>("nay").MapError(e => e.GetHashCode())).IsError("nay".GetHashCode());
+
+        await Assert.That(ErrorState.Error(new Exception("hello")).MapError(e => e.Message)).IsError("hello");
+        await Assert.That(ErrorState.Error(new Exception(null, new NotImplementedException())).MapError(e => e.InnerException!)).IsErrorOfType<NotImplementedException>();
+        await Assert.That(ErrorState.Error("nay").MapError(e => new Exception(e))).IsError();
+        await Assert.That(ErrorState.Error("nay").MapError(e => e.GetHashCode())).IsError("nay".GetHashCode());
+    }
+}

--- a/test/MapTests.cs
+++ b/test/MapTests.cs
@@ -8,10 +8,8 @@ public sealed class MapTests
         await Assert.That(Option.Success(1).Map(i => i + 1)).IsSuccess(2);
         await Assert.That(Option.Success(1).Map(i => Option.Success(i))).IsSuccess(1);
         await Assert.That(Result.Success(1).Map(i => i + 1)).IsSuccess(2);
-        await Assert.That(Result.Success(1).Map(i => i + 1, e => e.Message)).IsSuccess(2);
         await Assert.That(Result.Success(1).Map(i => Result.Success(i))).IsSuccess(1);
         await Assert.That(Result.Success<int, string>(1).Map(i => i + 1)).IsSuccess(2);
-        await Assert.That(Result.Success<int, int>(1).Map(i => i + 1, error => error.ToString())).IsSuccess(2);
         await Assert.That(Result.Success<int, string>(5).Map(i => i + 1, error => new Exception(error))).IsSuccess();
         await Assert.That(Result.Success<int, string>(1).Map(i => Result.Success<int, string>(i))).IsSuccess(1);
         await Assert.That(RefOption.Success<Span<char>>([]).Map(s => new string(s))).IsSuccess("");
@@ -34,11 +32,9 @@ public sealed class MapTests
         await Assert.That(Option.Error<int>().Map(i => Option.Success(i))).IsError();
         await Assert.That(Option.Success(1).Map(i => Option.Error<int>())).IsError();
         await Assert.That(Result.Error<int>().Map(i => i + 1)).IsError();
-        await Assert.That(Result.Error<int>().Map(i => i + 1, e => e.Message)).IsError();
         await Assert.That(Result.Error<int>(new FormatException()).Map(i => Result.Success(i))).IsErrorOfType<int, FormatException>();
         await Assert.That(Result.Success(1).Map(i => Result.Error<int>(new ArgumentException()))).IsErrorOfType<int, ArgumentException>();
         await Assert.That(Result.Error<int, string>("").Map(i => i + 1)).IsError("");
-        await Assert.That(Result.Error<int, int>(5).Map(i => i + 1, error => error.ToString())).IsError("5");
         await Assert.That(Result.Error<int, string>("5").Map(i => i + 1, error => new Exception(error))).IsError();
         await Assert.That(Result.Error<int, string>("nay").Map(i => Result.Success<int, string>(i))).IsError("nay");
         await Assert.That(Result.Success<int, string>(1).Map(i => Result.Error<int, string>("nay"))).IsError("nay");


### PR DESCRIPTION
replaces `Map(map, errorMap)` overloads