### PR TITLE
`(Try)Map(Error)` overloads with one argument

### DIFF
--- a/src/Nullable/Map.cs
+++ b/src/Nullable/Map.cs
@@ -10,6 +10,15 @@ public static class NullableMapExtensions
         where TValue : struct
         where TResult : class
         => value.HasValue ? map(value.Value) : null;
+
+    public static TResult? Map<TValue, TArg, TResult>(this TValue? value, TArg arg, Func<TValue, TArg, TResult> map)
+        where TValue : class
+        where TResult : class
+        => value is null ? null : map(value, arg);
+    public static TResult? Map<TValue, TArg, TResult>(this TValue? value, TArg arg, Func<TValue, TArg, TResult> map)
+        where TValue : struct
+        where TResult : class
+        => value.HasValue ? map(value.Value, arg) : null;
 }
 
 
@@ -23,4 +32,13 @@ public static class NullableValueMapExtensions
         where TValue : class
         where TResult : struct
         => value is null ? null : map(value);
+
+    public static TResult? Map<TValue, TArg, TResult>(this TValue? value, TArg arg, Func<TValue, TArg, TResult> map)
+        where TValue : struct
+        where TResult : struct
+        => value.HasValue ? map(value.Value, arg) : null;
+    public static TResult? Map<TValue, TArg, TResult>(this TValue? value, TArg arg, Func<TValue, TArg, TResult> map)
+        where TValue : class
+        where TResult : struct
+        => value is null ? null : map(value, arg);
 }

--- a/src/Operations/Map.cs
+++ b/src/Operations/Map.cs
@@ -2,7 +2,7 @@ namespace Ametrin.Optional;
 
 partial struct Option
 {
-    [Obsolete("Use Match")]
+    [Obsolete("Use Match", error: true)]
     public TResult Map<TResult>(Func<TResult> success, Func<TResult> error)
         => _success ? success() : error();
 }
@@ -13,43 +13,59 @@ partial struct Option<TValue>
         => _hasValue ? Option.Success(map(_value)) : default;
     public Option<TResult> Map<TResult>(Func<TValue, Option<TResult>> map)
         => _hasValue ? map(_value) : default;
+
+    public Option<TResult> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, TResult> map) where TArg : allows ref struct
+        => _hasValue ? Option.Success(map(_value, arg)) : default;
+    public Option<TResult> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, Option<TResult>> map) where TArg : allows ref struct
+        => _hasValue ? map(_value, arg) : default;
 }
 
 partial struct Result<TValue>
 {
     public Result<TResult> Map<TResult>(Func<TValue, TResult> map)
         => _hasValue ? map(_value) : _error;
-    
-    [Obsolete("use Map and MapError")]
+
+    [Obsolete("use Map and MapError", error: true)]
     public Result<TResult, TNewError> Map<TResult, TNewError>(Func<TValue, TResult> map, Func<Exception, TNewError> errorMap)
         => _hasValue ? map(_value) : errorMap(_error);
     public Result<TResult> Map<TResult>(Func<TValue, Result<TResult>> map)
         => _hasValue ? map(_value) : _error;
+
+    public Result<TResult> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, TResult> map) where TArg : allows ref struct
+        => _hasValue ? map(_value, arg) : _error;
+    public Result<TResult> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, Result<TResult>> map) where TArg : allows ref struct
+        => _hasValue ? map(_value, arg) : _error;
 }
 
 partial struct Result<TValue, TError>
 {
     public Result<TResult, TError> Map<TResult>(Func<TValue, TResult> map)
         => _hasValue ? map(_value) : _error;
+    [Obsolete("use Map and MapError", error: true)]
     public Result<TResult> Map<TResult>(Func<TValue, TResult> map, Func<TError, Exception> errorMap)
         => _hasValue ? map(_value) : errorMap(_error);
 
-    [Obsolete("use Map and MapError")]
+    [Obsolete("use Map and MapError", error: true)]
     public Result<TResult, TNewError> Map<TResult, TNewError>(Func<TValue, TResult> map, Func<TError, TNewError> errorMap)
         => _hasValue ? map(_value) : errorMap(_error);
     public Result<TResult, TError> Map<TResult>(Func<TValue, Result<TResult, TError>> map)
         => _hasValue ? map(_value) : _error;
+
+    public Result<TResult, TError> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, TResult> map) where TArg : allows ref struct
+        => _hasValue ? map(_value, arg) : _error;
+    public Result<TResult, TError> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, Result<TResult, TError>> map) where TArg : allows ref struct
+        => _hasValue ? map(_value, arg) : _error;
 }
 
 partial struct ErrorState
 {
-    [Obsolete("Use Match")]
+    [Obsolete("Use Match", error: true)]
     public TResult Map<TResult>(Func<TResult> success, Func<Exception, TResult> error) => _isError ? error(_error) : success();
 }
 
 partial struct ErrorState<TError>
 {
-    [Obsolete("Use Match")]
+    [Obsolete("Use Match", error: true)]
     public TResult Map<TResult>(Func<TResult> success, Func<TError, TResult> error) => _isError ? error(_error) : success();
 }
 
@@ -63,6 +79,15 @@ partial struct RefOption<TValue>
         => _hasValue ? map(_value) : default;
     public Option<TResult> Map<TResult>(Func<TValue, Option<TResult>> map)
         => _hasValue ? map(_value) : default;
+
+    public RefOption<TResult> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, TResult> map) where TArg : allows ref struct
+        where TResult : struct, allows ref struct
+        => _hasValue ? RefOption.Success(map(_value, arg)) : default;
+    public RefOption<TResult> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, RefOption<TResult>> map) where TArg : allows ref struct
+        where TResult : struct, allows ref struct
+        => _hasValue ? map(_value, arg) : default;
+    public Option<TResult> Map<TArg, TResult>(TArg arg, Func<TValue, TArg, Option<TResult>> map) where TArg : allows ref struct
+        => _hasValue ? map(_value, arg) : default;
 }
 
 public static class OptionMapExtensions
@@ -75,4 +100,13 @@ public static class OptionMapExtensions
     public static RefOption<TResult> Map<TValue, TResult>(this Option<TValue> option, Func<TValue, TResult> map)
         where TResult : struct, allows ref struct
         => option._hasValue ? RefOption.Success(map(option._value)) : default;
+
+    public static Option<TResult> Map<TValue, TArg, TResult>(this RefOption<TValue> option, TArg arg, Func<TValue, TArg, TResult> map) where TArg : allows ref struct
+        where TValue : struct, allows ref struct
+        where TResult : class
+        => option._hasValue ? Option.Success(map(option._value, arg)) : default;
+
+    public static RefOption<TResult> Map<TValue, TArg, TResult>(this Option<TValue> option, TArg arg, Func<TValue, TArg, TResult> map) where TArg : allows ref struct
+        where TResult : struct, allows ref struct
+        => option._hasValue ? RefOption.Success(map(option._value, arg)) : default;
 }

--- a/src/Operations/MapAsync.cs
+++ b/src/Operations/MapAsync.cs
@@ -17,6 +17,7 @@ partial struct Result<TValue>
         => _hasValue ? await map(_value) : _error;
     public Task<Result<TResult>> MapAsync<TResult>(Func<TValue, Task<Result<TResult>>> map)
         => _hasValue ? map(_value) : Task.FromResult(Result.Error<TResult>(_error));
+    [Obsolete("use MapAsync and MapError", error: true)]
     public async Task<Result<TResult, TError>> MapAsync<TResult, TError>(Func<TValue, Task<TResult>> map, Func<Exception, TError> errorMap)
         => _hasValue ? await map(_value) : errorMap(_error);
 }
@@ -28,8 +29,10 @@ partial struct Result<TValue, TError>
     public Task<Result<TResult, TError>> MapAsync<TResult>(Func<TValue, Task<Result<TResult, TError>>> map)
         => _hasValue ? map(_value) : Task.FromResult(Result.Error<TResult, TError>(_error));
     [OverloadResolutionPriority(1)]
+    [Obsolete("use MapAsync and MapError", error: true)]
     public async Task<Result<TResult>> MapAsync<TResult>(Func<TValue, Task<TResult>> map, Func<TError, Exception> errorMap)
         => _hasValue ? await map(_value) : errorMap(_error);
+    [Obsolete("use MapAsync and MapError", error: true)]
     public async Task<Result<TResult, TNewError>> MapAsync<TResult, TNewError>(Func<TValue, Task<TResult>> map, Func<TError, TNewError> errorMap)
         => _hasValue ? await map(_value) : errorMap(_error);
 }
@@ -51,13 +54,14 @@ public static class OptionMapAsyncExtensions
     public static async Task<Result<TResult>> MapAsync<TValue, TResult>(this Task<Result<TValue>> optionTask, Func<TValue, Result<TResult>> map)
         => (await optionTask).Map(map);
 
-    [Obsolete("use MapAsync and MapError")]
+    [Obsolete("use MapAsync and MapError", error: true)]
     public static async Task<Result<TResult, TNewError>> MapAsync<TValue, TResult, TNewError>(this Task<Result<TValue>> optionTask, Func<TValue, TResult> map, Func<Exception, TNewError> errorMap)
         => (await optionTask).Map(map, errorMap);
     public static async Task<Result<TResult>> MapAsync<TValue, TResult>(this Task<Result<TValue>> resultTask, Func<TValue, Task<TResult>> map)
         => await (await resultTask).MapAsync(map);
     public static async Task<Result<TResult>> MapAsync<TValue, TResult>(this Task<Result<TValue>> resultTask, Func<TValue, Task<Result<TResult>>> map)
         => await (await resultTask).MapAsync(map);
+    [Obsolete("use MapAsync and MapError", error: true)]
     public static async Task<Result<TResult, TError>> MapAsync<TValue, TResult, TError>(this Task<Result<TValue>> resultTask, Func<TValue, Task<TResult>> map, Func<Exception, TError> errorMap)
         => await (await resultTask).MapAsync(map, errorMap);
 
@@ -65,10 +69,11 @@ public static class OptionMapAsyncExtensions
         => (await optionTask).Map(map);
     
     [OverloadResolutionPriority(1)]
+    [Obsolete("use MapAsync and MapError", error: true)]
     public static async Task<Result<TResult, Exception>> MapAsync<TValue, TError, TResult>(this Task<Result<TValue, TError>> optionTask, Func<TValue, TResult> map, Func<TError, Exception> errorMap)
         => (await optionTask).Map(map, errorMap);
 
-    [Obsolete("use MapAsync and MapError")]
+    [Obsolete("use MapAsync and MapError", error: true)]
     public static async Task<Result<TResult, TNewError>> MapAsync<TValue, TError, TResult, TNewError>(this Task<Result<TValue, TError>> optionTask, Func<TValue, TResult> map, Func<TError, TNewError> errorMap)
         => (await optionTask).Map(map, errorMap);
     public static async Task<Result<TResult, TError>> MapAsync<TValue, TError, TResult>(this Task<Result<TValue, TError>> resultTask, Func<TValue, Task<TResult>> map)
@@ -77,8 +82,10 @@ public static class OptionMapAsyncExtensions
         => await (await resultTask).MapAsync(map);
     
     [OverloadResolutionPriority(1)]
+    [Obsolete("use MapAsync and MapError", error: true)]
     public static async Task<Result<TResult>> MapAsync<TValue, TError, TResult>(this Task<Result<TValue, TError>> resultTask, Func<TValue, Task<TResult>> map, Func<TError, Exception> errorMap)
         => await (await resultTask).MapAsync(map, errorMap);
+    [Obsolete("use MapAsync and MapError", error: true)]
     public static async Task<Result<TResult, TNewError>> MapAsync<TValue, TError, TResult, TNewError>(this Task<Result<TValue, TError>> resultTask, Func<TValue, Task<TResult>> map, Func<TError, TNewError> errorMap)
         => await (await resultTask).MapAsync(map, errorMap);
 }

--- a/src/Operations/MapError.cs
+++ b/src/Operations/MapError.cs
@@ -8,6 +8,11 @@ partial struct Result<TValue>
         => _hasValue ? _value : errorMap(_error);
     public Result<TValue> MapError(Func<Exception, Exception> errorMap)
         => _hasValue ? _value : errorMap(_error);
+    
+    public Result<TValue, TNewError> MapError<TArg, TNewError>(TArg arg, Func<Exception, TArg, TNewError> errorMap) where TArg : allows ref struct
+        => _hasValue ? _value : errorMap(_error, arg);
+    public Result<TValue> MapError<TArg>(TArg arg, Func<Exception, TArg, Exception> errorMap) where TArg : allows ref struct
+        => _hasValue ? _value : errorMap(_error, arg);
 }
 
 partial struct Result<TValue, TError>
@@ -16,6 +21,11 @@ partial struct Result<TValue, TError>
         => _hasValue ? _value : errorMap(_error);
     public Result<TValue, TNewError> MapError<TNewError>(Func<TError, TNewError> errorMap)
         => _hasValue ? _value : errorMap(_error);
+
+    public Result<TValue> MapError<TArg>(TArg arg, Func<TError, TArg, Exception> errorMap) where TArg : allows ref struct
+        => _hasValue ? _value : errorMap(_error, arg);
+    public Result<TValue, TNewError> MapError<TArg, TNewError>(TArg arg, Func<TError, TArg, TNewError> errorMap) where TArg : allows ref struct
+        => _hasValue ? _value : errorMap(_error, arg);
 }
 
 partial struct ErrorState
@@ -24,6 +34,11 @@ partial struct ErrorState
         => _isError ? errorMap(_error) : default(ErrorState<TNewError>);
     public ErrorState MapError(Func<Exception, Exception> errorMap)
         => _isError ? errorMap(_error) : default(ErrorState);
+        
+    public ErrorState<TNewError> MapError<TArg, TNewError>(TArg arg, Func<Exception, TArg, TNewError> errorMap) where TArg : allows ref struct
+        => _isError ? errorMap(_error, arg) : default(ErrorState<TNewError>);
+    public ErrorState MapError<TArg>(TArg arg, Func<Exception, TArg, Exception> errorMap) where TArg : allows ref struct
+        => _isError ? errorMap(_error, arg) : default(ErrorState);
 }
 
 partial struct ErrorState<TError>
@@ -32,6 +47,11 @@ partial struct ErrorState<TError>
         => _isError ? errorMap(_error) : default(ErrorState);
     public ErrorState<TNewError> MapError<TNewError>(Func<TError, TNewError> errorMap)
         => _isError ? errorMap(_error) : default(ErrorState<TNewError>);
+
+    public ErrorState MapError<TArg>(TArg arg, Func<TError, TArg, Exception> errorMap) where TArg : allows ref struct
+        => _isError ? errorMap(_error, arg) : default(ErrorState);
+    public ErrorState<TNewError> MapError<TArg, TNewError>(TArg arg, Func<TError, TArg, TNewError> errorMap) where TArg : allows ref struct
+        => _isError ? errorMap(_error, arg) : default(ErrorState<TNewError>);
 }
 
 public static class OptionMapErrorAsyncExtensions

--- a/src/Operations/TryMap.cs
+++ b/src/Operations/TryMap.cs
@@ -15,6 +15,21 @@ partial struct Option<TValue>
 
         return default;
     }
+
+    public Option<TResult> TryMap<TArg, TResult>(TArg arg, Func<TValue, TArg, TResult> map)
+        where TArg : allows ref struct
+    {
+        if (_hasValue)
+        {
+            try
+            {
+                return map(_value, arg);
+            }
+            catch { }
+        }
+
+        return default;
+    }
 }
 
 partial struct Result<TValue>
@@ -36,21 +51,27 @@ partial struct Result<TValue>
         }
     }
 
-    [Obsolete("use TryMap and MapError")]
+    [Obsolete("use TryMap and MapError", error: true)]
     public Result<TResult, TNewError> TryMap<TResult, TNewError>(Func<TValue, TResult> map, Func<Exception, TNewError> errormap)
+    {
+        return TryMap(map).MapError(errormap);
+    }
+
+    public Result<TResult> TryMap<TArg, TResult>(TArg arg, Func<TValue, TArg, TResult> map)
+        where TArg : allows ref struct
     {
         if (!_hasValue)
         {
-            return errormap(_error);
+            return _error;
         }
 
         try
         {
-            return map(_value);
+            return map(_value, arg);
         }
         catch (Exception e)
         {
-            return errormap(e);
+            return e;
         }
     }
 }
@@ -73,6 +94,24 @@ partial struct Result<TValue, TError>
             return errormap(e);
         }
     }
+
+    public Result<TResult, TError> TryMap<TArg, TResult>(TArg arg, Func<TValue, TArg, TResult> map, Func<Exception, TError> errormap)
+        where TArg : allows ref struct
+    {
+        if (!_hasValue)
+        {
+            return _error;
+        }
+
+        try
+        {
+            return map(_value, arg);
+        }
+        catch (Exception e)
+        {
+            return errormap(e);
+        }
+    }
 }
 
 partial struct RefOption<TValue>
@@ -88,6 +127,25 @@ partial struct RefOption<TValue>
         try
         {
             return map(_value);
+        }
+        catch
+        {
+            return default;
+        }
+    }
+
+    public RefOption<TResult> TryMap<TArg, TResult>(TArg arg, Func<TValue, TArg, TResult> map)
+        where TResult : struct, allows ref struct
+        where TArg : allows ref struct
+    {
+        if (!_hasValue)
+        {
+            return default;
+        }
+
+        try
+        {
+            return map(_value, arg);
         }
         catch
         {
@@ -122,6 +180,38 @@ public static class OptionTryMapExtensions
             try
             {
                 return RefOption.Success(map(option._value));
+            }
+            catch { }
+        }
+        return default;
+    }
+
+    public static Option<TResult> TryMap<TValue, TArg, TResult>(this RefOption<TValue> option, TArg arg, Func<TValue, TArg, TResult> map)
+        where TValue : struct, allows ref struct
+        where TResult : class
+        where TArg : allows ref struct
+    {
+        if (option._hasValue)
+        {
+            try
+            {
+                return map(option._value, arg);
+            }
+            catch { }
+        }
+
+        return default;
+    }
+
+    public static RefOption<TResult> TryMap<TValue, TArg, TResult>(this Option<TValue> option, TArg arg, Func<TValue, TArg, TResult> map)
+        where TResult : struct, allows ref struct
+        where TArg : allows ref struct
+    {
+        if (option._hasValue)
+        {
+            try
+            {
+                return RefOption.Success(map(option._value, arg));
             }
             catch { }
         }

--- a/test/MapAsyncTests.cs
+++ b/test/MapAsyncTests.cs
@@ -9,11 +9,8 @@ public sealed class MapAsyncTests
         await Assert.That(await Option.Success(1).MapAsync(async i => i + 1)).IsSuccess(2);
         await Assert.That(await Option.Success(1).MapAsync(async i => Option.Success(i))).IsSuccess(1);
         await Assert.That(await Result.Success(1).MapAsync(async i => i + 1)).IsSuccess(2);
-        await Assert.That(await Result.Success(1).MapAsync(async i => i + 1, e => e.Message)).IsSuccess(2);
         await Assert.That(await Result.Success(1).MapAsync(async i => Result.Success(i))).IsSuccess(1);
         await Assert.That(await Result.Success<int, string>(1).MapAsync(async i => i + 1)).IsSuccess(2);
-        await Assert.That(await Result.Success<int, int>(1).MapAsync(async i => i + 1, error => error.ToString())).IsSuccess(2);
-        await Assert.That(await Result.Success<int, string>(5).MapAsync(async i => i + 1, error => new FormatException(error))).IsSuccess();
         await Assert.That(await Result.Success<int, string>(1).MapAsync(async i => Result.Success<int, string>(i))).IsSuccess(1);
     }
 
@@ -26,11 +23,8 @@ public sealed class MapAsyncTests
         await Assert.That(await optionTask.MapAsync(async i => i + 1)).IsSuccess(2);
         await Assert.That(await optionTask.MapAsync(async i => Option.Success(i))).IsSuccess(1);
         await Assert.That(await resultTask.MapAsync(async i => i + 1)).IsSuccess(2);
-        await Assert.That(await resultTask.MapAsync(async i => i + 1, e => e.Message)).IsSuccess(2);
         await Assert.That(await resultTask.MapAsync(async i => Result.Success(i))).IsSuccess(1);
         await Assert.That(await result2Task.MapAsync(async i => i + 1)).IsSuccess(2);
-        await Assert.That(await Task.FromResult(Result.Success<int, int>(1)).MapAsync(async i => i + 1, error => error.ToString())).IsSuccess(2);
-        await Assert.That(await result2Task.MapAsync(async i => i + 1, error => new FormatException(error))).IsSuccess();
         await Assert.That(await result2Task.MapAsync(async i => Result.Success<int, string>(i))).IsSuccess(1);
 
 
@@ -39,7 +33,6 @@ public sealed class MapAsyncTests
         await Assert.That(await resultTask.MapAsync(i => i + 1)).IsSuccess(2);
         await Assert.That(await resultTask.MapAsync(i => Result.Success(i))).IsSuccess(1);
         await Assert.That(await result2Task.MapAsync(i => i + 1)).IsSuccess(2);
-        await Assert.That(await result2Task.MapAsync(i => i + 1, error => new FormatException(error))).IsSuccess();
         await Assert.That(await result2Task.MapAsync(i => Result.Success<int, string>(i))).IsSuccess(1);
     }
 
@@ -50,12 +43,9 @@ public sealed class MapAsyncTests
         await Assert.That(Option.Error<int>().MapAsync(async i => Option.Success(i))).IsError();
         await Assert.That(Option.Success(1).MapAsync(async i => Option.Error<int>())).IsError();
         await Assert.That(Result.Error<int>().MapAsync(async i => i + 1)).IsError();
-        await Assert.That(Result.Error<int>().MapAsync(async i => i + 1, e => e.Message)).IsError();
         await Assert.That(Result.Error<int>(new FormatException()).MapAsync(async i => Result.Success(i))).IsErrorOfType<int, FormatException>();
         await Assert.That(Result.Success(1).MapAsync(async i => Result.Error<int>(new ArgumentException()))).IsErrorOfType<int, ArgumentException>();
         await Assert.That(Result.Error<int, string>("").MapAsync(async i => i + 1)).IsError("");
-        await Assert.That(Result.Error<int, int>(5).MapAsync(async i => i + 1, error => error.ToString())).IsError("5");
-        await Assert.That(Result.Error<int, string>("5").MapAsync(async i => i + 1, error => new FormatException(error))).IsError();
         await Assert.That(Result.Error<int, string>("nay").MapAsync(async i => Result.Success<int, string>(i))).IsError("nay");
         await Assert.That(Result.Success<int, string>(1).MapAsync(async i => Result.Error<int, string>("nay"))).IsError("nay");
     }

--- a/test/MapErrorTests.cs
+++ b/test/MapErrorTests.cs
@@ -29,4 +29,32 @@ public sealed class MapErrorTests
         await Assert.That(ErrorState.Error("nay").MapError(e => new Exception(e))).IsError();
         await Assert.That(ErrorState.Error("nay").MapError(e => e.GetHashCode())).IsError("nay".GetHashCode());
     }
+    
+    [Test]
+    public async Task MapError_Arg_Success_Test()
+    {
+        await Assert.That(Result.Success(1).MapError(true, (e, a) => e.Message)).IsSuccess(1);
+        await Assert.That(Result.Success(1).MapError(true, (e, a) => e.InnerException!)).IsSuccess(1);
+        await Assert.That(Result.Success<int, string>(1).MapError(true, (e, a) => new Exception(e))).IsSuccess(1);
+        await Assert.That(Result.Success<int, string>(1).MapError(true, (e, a) => e.GetHashCode())).IsSuccess(1);
+
+        await Assert.That(ErrorState.Success().MapError(true, (e, a) => e.Message)).IsSuccess();
+        await Assert.That(ErrorState.Success().MapError(true, (e, a) => e.InnerException!)).IsSuccess();
+        await Assert.That(ErrorState.Success<string>().MapError(true, (e, a) => new Exception(e))).IsSuccess();
+        await Assert.That(ErrorState.Success<string>().MapError(true, (e, a) => e.GetHashCode())).IsSuccess();
+    }
+
+    [Test]
+    public async Task MapError_Arg_Error_Test()
+    {
+        await Assert.That(Result.Error<int>(new Exception("hello")).MapError(true, (e, a) => e.Message)).IsError("hello");
+        await Assert.That(Result.Error<int>(new Exception(null, new NotImplementedException())).MapError(true, (e, a) => e.InnerException!)).IsErrorOfType<int, NotImplementedException>();
+        await Assert.That(Result.Error<int, string>("nay").MapError(true, (e, a) => new Exception(e))).IsError();
+        await Assert.That(Result.Error<int, string>("nay").MapError(true, (e, a) => e.GetHashCode())).IsError("nay".GetHashCode());
+
+        await Assert.That(ErrorState.Error(new Exception("hello")).MapError(true, (e, a) => e.Message)).IsError("hello");
+        await Assert.That(ErrorState.Error(new Exception(null, new NotImplementedException())).MapError(true, (e, a) => e.InnerException!)).IsErrorOfType<NotImplementedException>();
+        await Assert.That(ErrorState.Error("nay").MapError(true, (e, a) => new Exception(e))).IsError();
+        await Assert.That(ErrorState.Error("nay").MapError(true, (e, a) => e.GetHashCode())).IsError("nay".GetHashCode());
+    }
 }

--- a/test/MapTests.cs
+++ b/test/MapTests.cs
@@ -10,10 +10,11 @@ public sealed class MapTests
         await Assert.That(Result.Success(1).Map(i => i + 1)).IsSuccess(2);
         await Assert.That(Result.Success(1).Map(i => Result.Success(i))).IsSuccess(1);
         await Assert.That(Result.Success<int, string>(1).Map(i => i + 1)).IsSuccess(2);
-        await Assert.That(Result.Success<int, string>(5).Map(i => i + 1, error => new Exception(error))).IsSuccess();
         await Assert.That(Result.Success<int, string>(1).Map(i => Result.Success<int, string>(i))).IsSuccess(1);
         await Assert.That(RefOption.Success<Span<char>>([]).Map(s => new string(s))).IsSuccess("");
+        await Assert.That(RefOption.Success<Span<char>>([]).Map(s => Option.Success(new string(s)))).IsSuccess("");
         await Assert.That(OptionsMarshall.IsSuccess(RefOption.Success<Span<char>>([]).Map(s => s))).IsTrue();
+        await Assert.That(OptionsMarshall.IsSuccess(RefOption.Success<Span<char>>([]).Map(s => RefOption.Success(s)))).IsTrue();
         await Assert.That(OptionsMarshall.IsSuccess(Option.Success("").MapAsSpan())).IsTrue();
         await Assert.That(new int?(1).Map(v => v * 2)).IsEqualTo(2);
         await Assert.That(new int?(1).Map(v => v.ToString())).IsEqualTo("1");
@@ -31,15 +32,59 @@ public sealed class MapTests
         await Assert.That(Result.Error<int>(new FormatException()).Map(i => Result.Success(i))).IsErrorOfType<int, FormatException>();
         await Assert.That(Result.Success(1).Map(i => Result.Error<int>(new ArgumentException()))).IsErrorOfType<int, ArgumentException>();
         await Assert.That(Result.Error<int, string>("").Map(i => i + 1)).IsError("");
-        await Assert.That(Result.Error<int, string>("5").Map(i => i + 1, error => new Exception(error))).IsError();
         await Assert.That(Result.Error<int, string>("nay").Map(i => Result.Success<int, string>(i))).IsError("nay");
         await Assert.That(Result.Success<int, string>(1).Map(i => Result.Error<int, string>("nay"))).IsError("nay");
         await Assert.That(RefOption.Error<Span<char>>().Map(s => new string(s))).IsError();
+        await Assert.That(RefOption.Error<Span<char>>().Map(s => Option.Success(new string(s)))).IsError();
         await Assert.That(OptionsMarshall.IsSuccess(RefOption.Error<Span<char>>().Map(s => s))).IsFalse();
+        await Assert.That(OptionsMarshall.IsSuccess(RefOption.Error<Span<char>>().Map(s => RefOption.Success(s)))).IsFalse();
         await Assert.That(OptionsMarshall.IsSuccess(Option.Error<string>().MapAsSpan())).IsFalse();
         await Assert.That(new int?().Map(v => v * 2)).IsNull();
         await Assert.That(new int?().Map(v => v.ToString())).IsNull();
         await Assert.That(((string?)null).Map(v => v + "a")).IsNull();
         await Assert.That(((string?)null).Map(int.Parse)).IsNull();
+    }
+
+    [Test]
+    public async Task Map_Arg_Success_Test()
+    {
+        await Assert.That(Option.Success(1).Map(true, (i, a) => a)).IsSuccess(true);
+        await Assert.That(Option.Success(1).Map(true, (i, a) => Option.Success(a))).IsSuccess(true);
+        await Assert.That(Result.Success(1).Map(true, (i, a) => a)).IsSuccess(true);
+        await Assert.That(Result.Success(1).Map(true, (i, a) => Result.Success(a))).IsSuccess(true);
+        await Assert.That(Result.Success<int, string>(1).Map(true, (i, a) => a)).IsSuccess(true);
+        await Assert.That(Result.Success<int, string>(1).Map(true, (i, a) => Result.Success<bool, string>(a))).IsSuccess(true);
+        await Assert.That(RefOption.Success<Span<char>>([]).Map("notempty", (s, a) => a)).IsSuccess("notempty");
+        await Assert.That(RefOption.Success<Span<char>>([]).Map("notempty", (s, a) => Option.Success(a))).IsSuccess("notempty");
+        await Assert.That(OptionsMarshall.IsSuccess(RefOption.Success<Span<char>>([]).Map(true, (s, a) => s))).IsTrue();
+        await Assert.That(OptionsMarshall.IsSuccess(RefOption.Success<Span<char>>([]).Map(true, (s, a) => RefOption.Success(s)))).IsTrue();
+        await Assert.That(OptionsMarshall.IsSuccess(Option.Success("").Map(true, (v, a) => v.AsSpan()))).IsTrue();
+        await Assert.That(new int?(1).Map(true, (v, a) => a)).IsEqualTo(true);
+        await Assert.That(new int?(1).Map(true, (v, a) => a.ToString())).IsEqualTo("True");
+        await Assert.That(((string?)"").Map(true, (v, a) => a.ToString())).IsEqualTo("True");
+        await Assert.That(((string?)"1").Map(true, (v, a) => a)).IsEqualTo(true);
+    }
+
+    [Test]
+    public async Task Map_Arg_Error_Test()
+    {
+        await Assert.That(Option.Error<int>().Map(true, (i, a) => i + 1)).IsError();
+        await Assert.That(Option.Error<int>().Map(true, (i, a) => Option.Success(i))).IsError();
+        await Assert.That(Option.Success(1).Map(true, (i, a) => Option.Error<int>())).IsError();
+        await Assert.That(Result.Error<int>().Map(true, (i, a) => i + 1)).IsError();
+        await Assert.That(Result.Error<int>(new FormatException()).Map(true, (i, a) => Result.Success(i))).IsErrorOfType<int, FormatException>();
+        await Assert.That(Result.Success(1).Map(true, (i, a) => Result.Error<int>(new ArgumentException()))).IsErrorOfType<int, ArgumentException>();
+        await Assert.That(Result.Error<int, string>("").Map(true, (i, a) => i + 1)).IsError("");
+        await Assert.That(Result.Error<int, string>("nay").Map(true, (i, a) => Result.Success<int, string>(i))).IsError("nay");
+        await Assert.That(Result.Success<int, string>(1).Map(true, (i, a) => Result.Error<int, string>("nay"))).IsError("nay");
+        await Assert.That(RefOption.Error<Span<char>>().Map(true, (s, a) => new string(s))).IsError();
+        await Assert.That(RefOption.Error<Span<char>>().Map(true, (s, a) => Option.Success(new string(s)))).IsError();
+        await Assert.That(OptionsMarshall.IsSuccess(RefOption.Error<Span<char>>().Map(true, (s, a) => s))).IsFalse();
+        await Assert.That(OptionsMarshall.IsSuccess(RefOption.Error<Span<char>>().Map(true, (s, a) => RefOption.Success(s)))).IsFalse();
+        await Assert.That(OptionsMarshall.IsSuccess(Option.Error<string>().Map(true, (v, a) => v.AsSpan()))).IsFalse();
+        await Assert.That(new int?().Map(true, (v, a) => v * 2)).IsNull();
+        await Assert.That(new int?().Map(true, (v, a) => v.ToString())).IsNull();
+        await Assert.That(((string?)null).Map(true, (v, a) => v + "a")).IsNull();
+        await Assert.That(((string?)null).Map(true, (v, a) => int.Parse(v))).IsNull();
     }
 }


### PR DESCRIPTION
this is useful to get ref structs into the mapping process and to reduce the need for closure allocations.

if more than one overload is needed a tuple can be used (or a custom ref struct if needed)